### PR TITLE
Modify the name of the chart object to call the getDatasetMeta function in the tooltip plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "chartjs-plugin-streaming",
-  "version": "3.0.2",
+  "name": "@robloche/chartjs-plugin-streaming",
+  "version": "3.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "chartjs-plugin-streaming",
-      "version": "3.0.2",
+      "name": "@robloche/chartjs-plugin-streaming",
+      "version": "3.0.4",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-json": "^6.0.0",

--- a/src/plugins/plugin.tooltip.js
+++ b/src/plugins/plugin.tooltip.js
@@ -7,7 +7,9 @@ export function update(...args) {
   const element = me.getActiveElements()[0];
 
   if (element) {
-    const meta = me._chart.getDatasetMeta(element.datasetIndex);
+    // 2023.01.04 
+    //const meta = me._chart.getDatasetMeta(element.datasetIndex);
+    const meta = me.chart.getDatasetMeta(element.datasetIndex);
 
     me.$streaming = getAxisMap(me, transitionKeys, meta);
   } else {


### PR DESCRIPTION
The name of the chart object that can use getDatasetMeta in "plugin.tooltip.js " is modified with the information changed by chart.js v4 update

const meta = me.__chart_.getDatasetMeta(element.datasetIndex);
 
const meta = me.**chart**.getDatasetMeta(element.datasetIndex);