### PR TITLE
Update plugin.annotation.js for new signature

### DIFF
--- a/src/plugins/plugin.annotation.js
+++ b/src/plugins/plugin.annotation.js
@@ -185,8 +185,7 @@ export function getElements(chart) {
   const plugin = chart.$streaming.annotationPlugin;
 
   if (plugin) {
-    const state = plugin._getState(chart);
-    return state && state.elements || [];
+    return plugin.getAnnotations(chart);
   }
   return [];
 }


### PR DESCRIPTION
This commit in chartjs-plugin-annotation got rid of the _getState private function and added a public getAnnotations one: https://github.com/chartjs/chartjs-plugin-annotation/commit/456e46b0f60ee1e8441198f1bb997e67c6a250a9